### PR TITLE
Add reboot button to settings page

### DIFF
--- a/blissflixx.py
+++ b/blissflixx.py
@@ -63,6 +63,8 @@ class Api(object):
       os.kill(os.getpid(), signal.SIGUSR2)
     elif fn == 'shutdown':
       os.system("sudo shutdown -h 0") 
+    elif fn == 'reboot':
+      os.system("sudo shutdown -r 0") 
     else:
       return self._error(404, "API Function '" + fn + "' is not defined")
 

--- a/html/pages/settings.html
+++ b/html/pages/settings.html
@@ -4,6 +4,7 @@
       <a href="#chanman" type="button" class="btn btn-primary btn-block btn-lg" ><span class="glyphicon glyphicon-th"></span> MANAGE CHANNELS</a>
       <a href="" onclick={ restart } type="button" class="btn btn-primary btn-block btn-lg"><span class="glyphicon glyphicon-retweet"></span> RESTART &amp; UPDATE</a>
       <a href="" onclick={ shutdown } type="button" class="btn btn-primary btn-block btn-lg"><span class="glyphicon glyphicon-off"></span> SHUTDOWN</a>
+      <a href="" onclick={ reboot } type="button" class="btn btn-primary btn-block btn-lg"><span class="glyphicon glyphicon-repeat"></span> REBOOT</a>
     </div>
   </div>
 
@@ -18,6 +19,12 @@
 
     shutdown() {
       Utils.rpc('server', 'shutdown', null, function(err) {
+        if (err) return Utils.showError(err)
+      })
+    }
+
+    reboot() {
+      Utils.rpc('server', 'reboot', null, function(err) {
         if (err) return Utils.showError(err)
       })
     }


### PR DESCRIPTION
Sometimes when there is a problem with the system that can´t be solved by a service restart, a reboot is much more useful than a shutdown since the user doesn't have to physically re-power the raspberry pi to continue using it.
This PR adds a reboot button to the settings page so that the user can restart the system without physical interaction.