### PR TITLE
Remove dependency on blissflixx.rocks

### DIFF
--- a/lib/chanutils/chanutils.py
+++ b/lib/chanutils/chanutils.py
@@ -2,7 +2,8 @@ import requests, lxml.html, re
 import htmlentitydefs, urllib, random
 from lxml.cssselect import CSSSelector
 
-_PROXY_LIST = None
+_PROXY_LIST = [{"url": "http://blissflixx-proxy1.appspot.com"}]
+
 
 _HEADERS = {
   'accept':'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',


### PR DESCRIPTION
While we figure out what to do next since blissflixx.rocks has been shut down.
Users only have to "RESTART & UPDATE" from the settings page to keep using Blissflixx. #42 