### PR TITLE
Fix twitch wrong feed

### DIFF
--- a/chls/bfch_twitch/__init__.py
+++ b/chls/bfch_twitch/__init__.py
@@ -1,5 +1,6 @@
 from chanutils import get_json
 from playitem import LiveStreamPlayItem, PlayItemList
+from urllib import quote_plus, unquote_plus
 
 _FEEDLIST_URL = 'https://api.twitch.tv/kraken/games/top?limit=50'
 _STREAM_URL = 'https://api.twitch.tv/kraken/streams'
@@ -15,11 +16,15 @@ def description():
   return "Twitch Channel (<a target='_blank' href='http://www.twitch.tv/'>http://www.twitch.tv/</a>)."
 
 def feedlist():
-  return map(lambda x: {'title' : x['game']['name']}, get_json(_FEEDLIST_URL)['top'])
+  return map(lambda x: {'title': x['game']['name'], 'name': quote_plus(x['game']['name'].encode('utf-8'))}, get_json(_FEEDLIST_URL)['top'])
 
 def feed(idx):
   gameName = feedlist()[idx]['title']
   streams = get_json(_STREAM_URL, {'limit':50, 'game': gameName})['streams']
+  return _extract(streams)
+
+def feed_by_name(idx, name):
+  streams = get_json(_STREAM_URL, {'limit':50, 'game': unquote_plus(name.encode('utf-8'))})['streams']
   return _extract(streams)
 
 def search(q):

--- a/html/js/ChannelStore.js
+++ b/html/js/ChannelStore.js
@@ -61,9 +61,31 @@ function ChannelStore() {
     }
   }
 
+  self.getParams = function(){
+    // if the current URL contains a string like "?p1=v1&p2=v2&p3=v3"
+    // return {"p1": v1, "p2": v2, "p3": v3}
+    const href = window.location.href
+    const params = href.split('?')[1]
+    // Be sure url params exist
+    if (params && params !== '') {
+      const result = params.split('&').reduce(function (res, item) {
+        const parts = item.split('=')
+        res[parts[0]] = parts[1]
+        return res
+      }, {})
+      return result
+    }
+  }
+
   self.getFeed = function(chid, idx, cb) {
     var key = self.createKey(chid, idx)
-    self.getResults(key, 'channels', 'feed', {chid:chid, idx:idx}, cb)
+    const params = self.getParams()
+    if (params && params['name']){
+      self.getResults(key, 'channels', 'feed_by_name', {chid:chid, idx:idx, name:params['name']}, cb)
+    }
+    else {
+      self.getResults(key, 'channels', 'feed', {chid:chid, idx:idx}, cb)
+    }
   }
 
   self.showMore = function(chid, link, cb) {

--- a/html/tags/feedlist.html
+++ b/html/tags/feedlist.html
@@ -2,7 +2,10 @@
    <div class="row">
     <div class="channel-feeds col-xs-12">
        <span each={ f, i in opts.feeds }>
-         <a class={ selected : i == parent.opts.active } href={ parent.opts.page + '/' + i }>{ f.title }</a>
+         <a class={ selected : ChannelStore.getParams() && ChannelStore.getParams()['name'] && 
+            f.name == ChannelStore.getParams()['name'] || i == parent.opts.active} 
+          href={ parent.opts.page + '/' + i + '?name=' + f.name } if={ f.name }>{ f.title }</a>
+         <a class={ selected : i == parent.opts.active } href={ parent.opts.page + '/' + i } if={ !f.name }>{ f.title }</a>
          <span hide={ i == parent.lastIdx } class="dot-sep">&#9679;</span>
        </span>
     </div>

--- a/lib/api/channels.py
+++ b/lib/api/channels.py
@@ -61,6 +61,9 @@ class Channel:
   def getFeed(self, idx):
     return self.getPlayItems(self.module.feed(idx))
 
+  def getFeedByName(self, idx, name):
+    return self.getPlayItems(self.module.feed_by_name(idx, name))
+
   def search(self, q):
     return self.getPlayItems(self.module.search(q))
 
@@ -187,6 +190,11 @@ def feed(chid=None, idx=None):
   if chid is None or idx is None:
     raise ApiError("Both Channel ID and feed index must be defined")
   return installed.getChannel(chid).getFeed(idx)
+
+def feed_by_name(chid=None, idx=None, name=None):
+  if chid is None or idx is None or name is None:
+    raise ApiError("All of Channel ID, feed index and name must be defined")
+  return installed.getChannel(chid).getFeedByName(idx, name)
 
 def search(chid=None, q=None):
   if chid is None or q is None:


### PR DESCRIPTION
The problem occurs because the feed is retrieved each time (it changes quite often) and it loses sync with the cached copy in the browser (html feed) and the data cache (js). This solution uses a querystring parameter so that the streams are returned based on the game name, not the index relative to the changing feed list.