### PR TITLE
Fix torrent index difference + yts images

### DIFF
--- a/chls/bfch_yts_torrents/__init__.py
+++ b/chls/bfch_yts_torrents/__init__.py
@@ -2,32 +2,32 @@ import chanutils.torrent
 from chanutils import get_json, movie_title_year
 from playitem import TorrentPlayItem, PlayItemList
 
-_SEARCH_URL = 'https://yts.ag/api/v2/list_movies.json'
+_SEARCH_URL = 'https://yts.mx/api/v2/list_movies.json'
 
 _FEEDLIST = [
-  {'title':'Latest', 'url':'https://yts.ag/api/v2/list_movies.json?limit=50'},
-  {'title':'Highest Rated', 'url':'https://yts.ag/api/v2/list_movies.json?sort_by=rating&limit=50'},
-  {'title':'Action', 'url':'https://yts.ag/api/v2/list_movies.json?genre=action&sort_by=rating&limit=50'},
-  {'title':'Adventure', 'url':'https://yts.ag/api/v2/list_movies.json?genre=adventure&sort_by=rating&limit=50'},
-  {'title':'Animation', 'url':'https://yts.ag/api/v2/list_movies.json?genre=animation&sort_by=rating&limit=50'},
-  {'title':'Biography', 'url':'https://yts.ag/api/v2/list_movies.json?genre=biography&sort_by=rating&limit=50'},
-  {'title':'Comedy', 'url':'https://yts.ag/api/v2/list_movies.json?genre=comedy&sort_by=rating&limit=50'},
-  {'title':'Crime', 'url':'https://yts.ag/api/v2/list_movies.json?genre=crime&sort_by=rating&limit=50'},
-  {'title':'Documentary', 'url':'https://yts.ag/api/v2/list_movies.json?genre=documentary&sort_by=rating&limit=50'},
-  {'title':'Drama', 'url':'https://yts.ag/api/v2/list_movies.json?genre=drama&sort_by=rating&limit=50'},
-  {'title':'Family', 'url':'https://yts.ag/api/v2/list_movies.json?genre=family&sort_by=rating&limit=50'},
-  {'title':'Fantasy', 'url':'https://yts.ag/api/v2/list_movies.json?genre=fantasy&sort_by=rating&limit=50'},
-  {'title':'Film-Noir', 'url':'https://yts.ag/api/v2/list_movies.json?genre=filmnoir&sort_by=rating&limit=50'},
-  {'title':'History', 'url':'https://yts.ag/api/v2/list_movies.json?genre=history&sort_by=rating&limit=50'},
-  {'title':'Horror', 'url':'https://yts.ag/api/v2/list_movies.json?genre=horror&sort_by=rating&limit=50'},
-  {'title':'Music', 'url':'https://yts.ag/api/v2/list_movies.json?genre=music&sort_by=rating&limit=50'},
-  {'title':'Musical', 'url':'https://yts.ag/api/v2/list_movies.json?genre=musical&sort_by=rating&limit=50'},
-  {'title':'Mystery', 'url':'https://yts.ag/api/v2/list_movies.json?genre=mystery&sort_by=rating&limit=50'},
-  {'title':'Romance', 'url':'https://yts.ag/api/v2/list_movies.json?genre=romance&sort_by=rating&limit=50'},
-  {'title':'Sci-Fi', 'url':'https://yts.ag/api/v2/list_movies.json?genre=scifi&sort_by=rating&limit=50'},
-  {'title':'Sport', 'url':'https://yts.ag/api/v2/list_movies.json?genre=sport&sort_by=rating&limit=50'},
-  {'title':'Thriller', 'url':'https://yts.ag/api/v2/list_movies.json?genre=thriller&sort_by=rating&limit=50'},
-  {'title':'War', 'url':'https://yts.ag/api/v2/list_movies.json?genre=western&sort_by=rating&limit=50'},
+  {'title':'Latest', 'url':'https://yts.mx/api/v2/list_movies.json?limit=50'},
+  {'title':'Highest Rated', 'url':'https://yts.mx/api/v2/list_movies.json?sort_by=rating&limit=50'},
+  {'title':'Action', 'url':'https://yts.mx/api/v2/list_movies.json?genre=action&sort_by=rating&limit=50'},
+  {'title':'Adventure', 'url':'https://yts.mx/api/v2/list_movies.json?genre=adventure&sort_by=rating&limit=50'},
+  {'title':'Animation', 'url':'https://yts.mx/api/v2/list_movies.json?genre=animation&sort_by=rating&limit=50'},
+  {'title':'Biography', 'url':'https://yts.mx/api/v2/list_movies.json?genre=biography&sort_by=rating&limit=50'},
+  {'title':'Comedy', 'url':'https://yts.mx/api/v2/list_movies.json?genre=comedy&sort_by=rating&limit=50'},
+  {'title':'Crime', 'url':'https://yts.mx/api/v2/list_movies.json?genre=crime&sort_by=rating&limit=50'},
+  {'title':'Documentary', 'url':'https://yts.mx/api/v2/list_movies.json?genre=documentary&sort_by=rating&limit=50'},
+  {'title':'Drama', 'url':'https://yts.mx/api/v2/list_movies.json?genre=drama&sort_by=rating&limit=50'},
+  {'title':'Family', 'url':'https://yts.mx/api/v2/list_movies.json?genre=family&sort_by=rating&limit=50'},
+  {'title':'Fantasy', 'url':'https://yts.mx/api/v2/list_movies.json?genre=fantasy&sort_by=rating&limit=50'},
+  {'title':'Film-Noir', 'url':'https://yts.mx/api/v2/list_movies.json?genre=filmnoir&sort_by=rating&limit=50'},
+  {'title':'History', 'url':'https://yts.mx/api/v2/list_movies.json?genre=history&sort_by=rating&limit=50'},
+  {'title':'Horror', 'url':'https://yts.mx/api/v2/list_movies.json?genre=horror&sort_by=rating&limit=50'},
+  {'title':'Music', 'url':'https://yts.mx/api/v2/list_movies.json?genre=music&sort_by=rating&limit=50'},
+  {'title':'Musical', 'url':'https://yts.mx/api/v2/list_movies.json?genre=musical&sort_by=rating&limit=50'},
+  {'title':'Mystery', 'url':'https://yts.mx/api/v2/list_movies.json?genre=mystery&sort_by=rating&limit=50'},
+  {'title':'Romance', 'url':'https://yts.mx/api/v2/list_movies.json?genre=romance&sort_by=rating&limit=50'},
+  {'title':'Sci-Fi', 'url':'https://yts.mx/api/v2/list_movies.json?genre=scifi&sort_by=rating&limit=50'},
+  {'title':'Sport', 'url':'https://yts.mx/api/v2/list_movies.json?genre=sport&sort_by=rating&limit=50'},
+  {'title':'Thriller', 'url':'https://yts.mx/api/v2/list_movies.json?genre=thriller&sort_by=rating&limit=50'},
+  {'title':'War', 'url':'https://yts.mx/api/v2/list_movies.json?genre=western&sort_by=rating&limit=50'},
 ]
 
 def name():
@@ -37,7 +37,7 @@ def image():
   return 'icon.png'
 
 def description():
-  return "YTS Torrents Channel (<a target='_blank' href='https://yts.ag'>https://yts.ag</a>)."
+  return "YTS Torrents Channel (<a target='_blank' href='https://yts.mx'>https://yts.mx</a>)."
 
 def feedlist():
   return _FEEDLIST
@@ -65,7 +65,7 @@ def _extract(data):
     title = r['title_long']
     img = r['medium_cover_image']
     # Proxy
-    img = "https://images.weserv.nl/?url=yts.ag" + img[14:]
+    img = "https://img.yts.mx" + img[14:]
     url = torrent['url']
     size = torrent['size']
     seeds = torrent['seeds']

--- a/lib/chanutils/torrent/__init__.py
+++ b/lib/chanutils/torrent/__init__.py
@@ -42,6 +42,8 @@ def peerflix_metadata(link):
     delim = l.rfind(':')
     if delim == -1:
       break
+    if "Verifying downloaded:" in l:
+      continue
     files.append((l[20:delim-6], l[delim+7:-5]))
   return files
 


### PR DESCRIPTION
The problem with the torrent files was that peerflix shows an additional line with "Verifying downloaded:". I removed it and tested and now the right file plays.
Although yts.ag redirects to yts.mx I changed every appearance to save precious time on each connection.
Also fixed the image URL.
Fixes #66 and #67.